### PR TITLE
Update systemd file according to new version of communication_link

### DIFF
--- a/packaging/systemd/system/communication_link.service
+++ b/packaging/systemd/system/communication_link.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=always
 RestartSec=2
 EnvironmentFile=/enclave/drone_device_id
-ExecStart=/bin/bash -c ". /opt/ros/foxy/setup.bash; /usr/bin/communication_link -device_id ${DRONE_DEVICE_ID}"
+ExecStart=/bin/bash -c ". /opt/ros/foxy/setup.bash; /usr/bin/communication_link -device_id ${DRONE_DEVICE_ID} -private_key /enclave/rsa_private.pem"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Instead of reading private key string from hard-coded file path the
communication_link now reads the file path from command line parameter