### PR TITLE
Update systemd scripts to source drone-specific environment variables

### DIFF
--- a/packaging/systemd/package.sh
+++ b/packaging/systemd/package.sh
@@ -14,6 +14,8 @@ make_deb() {
 	cp debian/postinst ${build_dir}/DEBIAN/
 	cp debian/prerm ${build_dir}/DEBIAN/
 	cp system/* ${build_dir}/etc/systemd/system/
+	mkdir -p ${build_dir}/opt/ros/foxy
+	cp setup_fog.sh ${build_dir}/opt/ros/foxy/
 
 	get_version
 	sed -i "s/VERSION/${version}/" ${build_dir}/DEBIAN/control

--- a/packaging/systemd/setup_fog.sh
+++ b/packaging/systemd/setup_fog.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Source local variables for this script
+. /enclave/drone_device_id
+
+# Export global environment variables
+export DRONE_DEVICE_ID
+
+# Source ROS paths
+. /opt/ros/foxy/setup.sh

--- a/packaging/systemd/system/communication_link.service
+++ b/packaging/systemd/system/communication_link.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=always
 RestartSec=2
 EnvironmentFile=/enclave/drone_device_id
-ExecStart=/bin/bash -c ". /opt/ros/foxy/setup.bash; /usr/bin/communication_link -device_id ${DRONE_DEVICE_ID} -private_key /enclave/rsa_private.pem"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /usr/bin/communication_link -device_id $DRONE_DEVICE_ID -private_key /enclave/rsa_private.pem"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/system/micrortps_agent.service
+++ b/packaging/systemd/system/micrortps_agent.service
@@ -4,10 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Environment=ROS_HOSTNAME=localhost
-Environment=ROS_MASTER_URI=http://localhost:11311
-Environment=ROS_LOG_DIR=/var/log/sad/log
-ExecStart=/bin/sh -c ". /opt/ros/foxy/setup.sh; micrortps_agent -t UDP -r 2020 -s 2019"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; micrortps_agent -t UDP -r 2020 -s 2019 -n $DRONE_DEVICE_ID"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/system/px4_mavlink_ctrl.service
+++ b/packaging/systemd/system/px4_mavlink_ctrl.service
@@ -5,7 +5,7 @@ Description=PX4 Mavlink Message Control Service
 Type=simple
 User=root
 Group=root
-ExecStart=/bin/bash -c ". /opt/ros/foxy/setup.bash; ros2 launch px4_mavlink_ctrl mavlink_ctrl.launch"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; ros2 launch px4_mavlink_ctrl mavlink_ctrl.launch"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add a new setup_fog.sh script, which sets drone-specific variables and
sources the ros environment

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>