### PR TITLE
Fix depthai ctrl init

### DIFF
--- a/packaging/systemd/debian/postinst
+++ b/packaging/systemd/debian/postinst
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service mesh.service
+systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service mesh.service depthai_ctrl.service

--- a/packaging/systemd/debian/postinst
+++ b/packaging/systemd/debian/postinst
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service indoor_pos.service depthai_ctrl mesh.service
+systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service mesh.service

--- a/packaging/systemd/system/depthai_ctrl.service
+++ b/packaging/systemd/system/depthai_ctrl.service
@@ -8,7 +8,7 @@ User=sad
 Group=sad
 Restart=always
 RestartSec=10
-ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /usr/bin/depthai_ctrl"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/roxy/bin/depthai_ctrl"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/system/depthai_ctrl.service
+++ b/packaging/systemd/system/depthai_ctrl.service
@@ -8,7 +8,7 @@ User=sad
 Group=sad
 Restart=always
 RestartSec=10
-ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/foxy/bin/depthai_ctrl"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/foxy/bin/depthai_ctrl --ros-args --remap __ns:=$(env DRONE_DEVICE_ID)"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/system/depthai_ctrl.service
+++ b/packaging/systemd/system/depthai_ctrl.service
@@ -8,7 +8,7 @@ User=sad
 Group=sad
 Restart=always
 RestartSec=10
-ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/roxy/bin/depthai_ctrl"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/foxy/bin/depthai_ctrl"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/system/depthai_ctrl.service
+++ b/packaging/systemd/system/depthai_ctrl.service
@@ -8,7 +8,7 @@ User=sad
 Group=sad
 Restart=always
 RestartSec=10
-ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/foxy/bin/depthai_ctrl --ros-args --remap __ns:=$(env DRONE_DEVICE_ID)"
+ExecStart=/bin/sh -c ". /opt/ros/foxy/setup_fog.sh; /opt/ros/foxy/bin/depthai_ctrl --ros-args --remap __ns:=/$DRONE_DEVICE_ID"
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/udev-rules/80-movidius.rules
+++ b/packaging/systemd/udev-rules/80-movidius.rules
@@ -1,5 +1,7 @@
 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
+#SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", MODE="0666",  GROUP="plugdev"
+#SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", MODE="0666",  GROUP="plugdev"
 
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"

--- a/packaging/systemd/udev-rules/80-movidius.rules
+++ b/packaging/systemd/udev-rules/80-movidius.rules
@@ -1,0 +1,5 @@
+
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
+
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666",  GROUP="plugdev"
+

--- a/packaging/systemd/udev-rules/80-movidius.rules
+++ b/packaging/systemd/udev-rules/80-movidius.rules
@@ -1,5 +1,5 @@
 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="depthai_ctrl.service"
 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666",  GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", ATTRS{idProduct}=="2485", MODE="0666",  GROUP="plugdev"
 


### PR DESCRIPTION
Fixes:
Wrong path to depthai_ctrl binary.
Use correct drone device ID environment variable for ROS2 namespace.
Clean up list of services which will start during boot.
FYI, @jnippula 