### PR TITLE
Add missing dependency to communication_link package

### DIFF
--- a/packaging/communication_link/debian/control
+++ b/packaging/communication_link/debian/control
@@ -2,5 +2,5 @@ Package: communication-link
 Version: VERSION
 Maintainer: Jari Nippula <jarix@ssrc.tii.ae>
 Architecture: amd64
-Depends:
+Depends: gstreamer1.0-rtsp
 Description: Communication link for drone cloud connection


### PR DESCRIPTION
The videonode installed by communication_link package has a dependency
to GStreamer RTSP client plugin.