### PR TITLE
LIttle fix for protocol_splitter

### DIFF
--- a/packaging/agent_protocol_splitter/package.sh
+++ b/packaging/agent_protocol_splitter/package.sh
@@ -8,10 +8,12 @@ get_version() {
 }
 
 build() {
-	pushd ../../agent_protocol_splitter/src
+	mkdir ../../agent_protocol_splitter/build
+	pushd ../../agent_protocol_splitter/build
 	cmake ..
 	make || exit 1
 	cp protocol_splitter ../../packaging/agent_protocol_splitter/ && make clean
+	rm -dr ../../agent_protocol_splitter/build
         popd
 }
 

--- a/packaging/agent_protocol_splitter/package.sh
+++ b/packaging/agent_protocol_splitter/package.sh
@@ -8,7 +8,7 @@ get_version() {
 }
 
 build() {
-	mkdir ../../agent_protocol_splitter/build
+	mkdir -p ../../agent_protocol_splitter/build
 	pushd ../../agent_protocol_splitter/build
 	cmake ..
 	make || exit 1


### PR DESCRIPTION
Fix for protocol_splitter, such that no temporal build files remain in 'src' folder.

Hi @jlaitine , last time I tried to fix with .gitignore, but you didn't like that.
Here is a proper fix.