### PR TITLE
Set submodule urls to https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,7 +81,7 @@
 	url = https://github.com/tiiuae/fog_gazebo_resources.git
 [submodule "mission-data-recorder"]
 	path = mission-data-recorder
-	url = git@github.com:tiiuae/mission-data-recorder.git
+	url = https://github.com/tiiuae/mission-data-recorder.git
 [submodule "ros2_ws/src/mocap_pose"]
 	path = ros2_ws/src/mocap_pose
-	url = git@github.com:tiiuae/mocap_pose.git
+	url = https://github.com/tiiuae/mocap_pose.git


### PR DESCRIPTION
Having ssh urls make it impossible for people outside our team to
clone the fog-sw, which is otherwise public

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>