### PR TITLE
build environment fixes

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -40,7 +40,7 @@ def clone(c, public=True):
             submodules.remove('ros2_ws/src/mesh_com')
             c.run("git submodule update ros2_ws/src/mesh_com")
         for sub in submodules:
-            c.run("git submodule update --recursive %s" %sub)
+            c.run("git submodule update --init --recursive %s" %sub)
 
 @task(
     help={'nocache': "do not use cache when building the image",

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -104,4 +104,6 @@ fi
 echo "--- Updating rosdep"
 rosdep update
 
+sudo apt-get upgrade -y
+
 exit 0


### PR DESCRIPTION
Run apt-get upgrade in docker environment to get the latest updates not
available in ros base image.

Fix invoke clone command for recursive submodules.